### PR TITLE
Update max-length to None

### DIFF
--- a/PaperCompanion/ui/message_bubble.py
+++ b/PaperCompanion/ui/message_bubble.py
@@ -113,11 +113,12 @@ class MessageBubble(QWidget):
         bubble.setObjectName(object_name)
         bubble.setStyleSheet(f"""
             #{object_name} {{
-                background-color: {bg_color};
-                border: 1px solid {border_color};
-                border-radius: {border_radius};
-                padding: 8px;
-                min-width: 200px;
+            background-color: {bg_color};
+            border: 1px solid {border_color};
+            border-radius: {border_radius};
+            padding: 8px;
+            min-width: 200px;
+            max-width: none;
             }}
         """)
         


### PR DESCRIPTION
This pull request includes a small change to the `create_bubble` method in `PaperCompanion/ui/message_bubble.py`. The change removes the maximum width restriction for message bubbles by setting `max-width` to `none`.